### PR TITLE
Guard icpMap mutex when doing registration

### DIFF
--- a/norlab_icp_mapper/Mapper.cpp
+++ b/norlab_icp_mapper/Mapper.cpp
@@ -76,10 +76,11 @@ void norlab_icp_mapper::Mapper::processInput(const PM::DataPoints& inputInSensor
 	}
 	else
 	{
-		icpMapLock.lock();
-		PM::TransformationParameters correction = icp(input);
-		icpMapLock.unlock();
-
+		PM::TransformationParameters correction;
+		{
+			std::lock_guard<std::mutex> icpMapLockGuard(icpMapLock);
+			correction = icp(input);
+		}
 		correctedPose = correction * estimatedPose;
 
 		map.updatePose(correctedPose);


### PR DESCRIPTION
An exception thrown in `icp()` function would leave the `icpMapLock` mutex locked, so any operation on the map, such as export, was impossible. 