### PR TITLE
Fix a blocked map update thread

### DIFF
--- a/norlab_icp_mapper/Mapper.cpp
+++ b/norlab_icp_mapper/Mapper.cpp
@@ -217,7 +217,7 @@ void norlab_icp_mapper::Mapper::processInput(const PM::DataPoints& inputInSensor
 		}
 	}
 
-    if(mapUpdateFuture.wait_for(std::chrono::milliseconds (1)) == std::future_status::ready)
+    if (mapUpdateFuture.valid() && mapUpdateFuture.wait_for(std::chrono::milliseconds(1)) == std::future_status::ready)
     {
         mapUpdateFuture.get();
     }

--- a/norlab_icp_mapper/Mapper.cpp
+++ b/norlab_icp_mapper/Mapper.cpp
@@ -217,6 +217,11 @@ void norlab_icp_mapper::Mapper::processInput(const PM::DataPoints& inputInSensor
 		}
 	}
 
+    if(mapUpdateFuture.wait_for(std::chrono::milliseconds (1)) == std::future_status::ready)
+    {
+        mapUpdateFuture.get();
+    }
+
 	poseLock.lock();
 	pose = correctedPose;
 	poseLock.unlock();
@@ -270,7 +275,6 @@ void norlab_icp_mapper::Mapper::updateMap(const PM::DataPoints& currentInput, co
 	if(isOnline && !map.isLocalPointCloudEmpty())
 	{
 		mapUpdateFuture = std::async(std::launch::async, &Map::updateLocalPointCloud, &map, currentInput, currentPose, mapPostFilters);
-        mapUpdateFuture.get();
 	}
 	else
 	{

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,9 +7,9 @@ sdist.cmake = true
 cmake.verbose = true
 
 [project]
-version = "1.1.0"
+version = "2.0.0"
 name = "pynorlab_icp_mapper"
-dependencies = ["numpy>=1.20", "pypointmatcher>=1.4.2"]
+dependencies = ["numpy>=1.20", "pypointmatcher>=1.4.3"]
 classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
This commit fixes a bug I introduced some time ago while trying to get meaningful libpointmatcher exceptions propagated from the `mapping thread` to the mapper.
While https://github.com/norlab-ulaval/norlab_icp_mapper/blob/398a9b2a362c7d7e9d99ba34b173c5455290384c/norlab_icp_mapper/Mapper.cpp#L273 
returns the exception thrown by libpointmatcher, it also waits until the future is ready, effectively blocking the main (localization thread) until the mapping is finished.
This PR fixes the issue by checking the status of the future in every execution of the localization loop. If the mapping future's status is ready, the `mapping thread` is finished, and we can access its results.

Tested on a Warthog's rosbag.