### PR TITLE
Fix missing features in saved trajectory

### DIFF
--- a/norlab_icp_mapper/Trajectory.cpp
+++ b/norlab_icp_mapper/Trajectory.cpp
@@ -24,6 +24,7 @@ void Trajectory::save(std::string filename) const
     featureLabels.push_back(PointMatcher<float>::DataPoints::Label("pad", 1));
 
     Eigen::MatrixXf features(dimension, poses.size() + 1);
+    Eigen::MatrixXf features(dimension + 1, poses.size());
 
     PointMatcher<float>::DataPoints::Labels descriptorLabels;
     descriptorLabels.push_back(PointMatcher<float>::DataPoints::Label("orientationX", dimension));

--- a/norlab_icp_mapper/Trajectory.cpp
+++ b/norlab_icp_mapper/Trajectory.cpp
@@ -21,7 +21,9 @@ void Trajectory::save(std::string filename) const
     {
         featureLabels.push_back(PointMatcher<float>::DataPoints::Label("z", 1));
     }
-    Eigen::MatrixXf features(dimension, poses.size());
+    featureLabels.push_back(PointMatcher<float>::DataPoints::Label("pad", 1));
+
+    Eigen::MatrixXf features(dimension, poses.size() + 1);
 
     PointMatcher<float>::DataPoints::Labels descriptorLabels;
     descriptorLabels.push_back(PointMatcher<float>::DataPoints::Label("orientationX", dimension));
@@ -38,7 +40,9 @@ void Trajectory::save(std::string filename) const
 
     for(size_t i = 0; i < poses.size(); ++i)
     {
-        features.col(i) = poses[i].topRightCorner(dimension, 1);
+        Eigen::Vector4f col;
+        col << poses[i].topRightCorner(dimension, 1), 1.0;
+        features.col(i) = col;
         descriptors.block(0, i, dimension, 1) = poses[i].block(0, 0, dimension, 1);
         descriptors.block(dimension, i, dimension, 1) = poses[i].block(0, 1, dimension, 1);
         if(dimension == 3)

--- a/norlab_icp_mapper/Trajectory.cpp
+++ b/norlab_icp_mapper/Trajectory.cpp
@@ -27,7 +27,7 @@ void Trajectory::save(std::string filename) const
 
             auto timestamp = timeStamps.at(i);
 
-            // export timeestamp
+            // export timestamp
             file << timestamp.time_since_epoch().count() << " ";
             // export x y z
             file << pose(0, 3) << " " << pose(1, 3) << " " << pose(2, 3) << " ";


### PR DESCRIPTION
Add padding to the libpointmatcher trajectory object created by the mapper in order to properly save the trajectory in `pcd`, `ply`, and `csv` formats. 

Addresses https://github.com/norlab-ulaval/norlab_icp_mapper_ros/issues/17 and https://github.com/norlab-ulaval/libpointmatcher/issues/606
