### PR TITLE
Set newLocalPointCloudAvailable to true when a new map is loaded

### DIFF
--- a/norlab_icp_mapper/Map.cpp
+++ b/norlab_icp_mapper/Map.cpp
@@ -585,4 +585,5 @@ void norlab_icp_mapper::Map::setGlobalPointCloud(const PM::DataPoints& newLocalP
 
 	firstPoseUpdate.store(true);
 	localPointCloudLock.unlock();
+	newLocalPointCloudAvailable = true;
 }


### PR DESCRIPTION
 for example from a file.